### PR TITLE
feat: action mock toggles

### DIFF
--- a/src/data/services/lms/hooks/actions/index.ts
+++ b/src/data/services/lms/hooks/actions/index.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 
 import { camelCaseObject } from '@edx/frontend-platform';
@@ -6,70 +7,65 @@ import { stepNames, stepRoutes, queryKeys } from 'constants';
 import { progressKeys } from 'constants/mockData';
 
 import * as api from 'data/services/lms/api';
-import { AssessmentData } from 'data/services/lms/types';
+// import { AssessmentData } from 'data/services/lms/types';
 import { loadState } from 'data/services/lms/fakeData/dataStates';
+import { useTestDataPath } from 'hooks/test';
 
 import { useViewStep } from 'hooks/routing';
 
-import { useCreateMutationAction } from './utils';
 export * from './files';
 
-export const useSubmitAssessment = ({ onSuccess }) => useMutation({
-  mutationFn: (data: AssessmentData) => (
-    api.submitAssessment(data).then((response) => {
-      console.log({ submitAssessmentResponse: response });
-      return response;
-    })
-  ),
-  onSuccess,
+const apiLog = (apiMethod, name) => (data) => apiMethod(data).then(response => {
+  console.log({ [name]: response });
+  return response;
 });
 
-export const useSubmitResponse = () => {
-  const step = useViewStep();
-  const queryClient = useQueryClient();
+export const useSubmitAssessment = ({ onSuccess } = {}) => {
+  const testDataPath = useTestDataPath();
+  const apiFn = api.submitAssessment;
+  const mockFn = React.useCallback((data) => Promise.resolve(data), []);
   return useMutation({
-    mutationFn: () => {
-      const state = camelCaseObject(loadState({
-        view: stepRoutes[step],
-        progressKey: progressKeys.studentTraining,
-      }));
-      console.log({ state });
-      queryClient.setQueryData([queryKeys.pageData], state);
-      return Promise.resolve(state);
-    },
+    mutationFn: apiLog(testDataPath ? mockFn : apiFn, 'submittedAssessment'),
+    onSuccess,
   });
-  /*
-  return useCreateMutationAction(
-    async (data: any, queryClient) => {
-      // TODO: submit response
-      await api.submitResponse(data);
-      queryClient.invalidateQueries([queryKeys.pageData, false]);
-    },
-  );
-  */
 };
 
-export const useSaveResponse = () => useCreateMutationAction(
-  async (data: any, queryClient) => {
-    // TODO: save response for later
-    await api.saveResponse(data);
-    // queryClient.invalidateQueries([queryKeys.pageData, false]);
-    return Promise.resolve(data);
-  },
-);
+export const useSubmitResponse = ({ onSuccess } = {}) => {
+  const testDataPath = useTestDataPath();
+  const step = useViewStep();
+  const queryClient = useQueryClient();
+
+  const mockFn = React.useCallback(() => {
+    const state = camelCaseObject(loadState({
+      view: stepRoutes[step],
+      progressKey: progressKeys.studentTraining,
+    }));
+    queryClient.setQueryData([queryKeys.pageData], state);
+    return Promise.resolve(state);
+  }, [queryClient, step]);
+  const apiFn = api.submitAssessment;
+
+  return useMutation({
+    mutationFn: apiLog(testDataPath ? mockFn : apiFn, 'submittedResponse'),
+    onSuccess,
+  });
+};
+
+export const useSaveDraftResponse = ({ onSuccess } = {}) => {
+  // const queryClient = useQueryClient();
+  const testDataPath = useTestDataPath();
+
+  const apiFn = apiLog(api.saveResponse, 'saveDraftResponse');
+
+  const mockFn = React.useCallback((data) => Promise.resolve(data), []);
+
+  return useMutation({
+    mutationFn: apiLog(testDataPath ? mockFn : apiFn, 'savedDraftResponse'),
+    onSuccess,
+  });
+};
 
 export const useRefreshPageData = () => {
   const queryClient = useQueryClient();
-  const step = useViewStep();
-  /*
-  return () => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.pageData });
-    console.log("invalidated")
-  };
-  */
-  /* Test facilitation */
-  return () => {
-    console.log("REFRESH");
-    return queryClient.invalidateQueries({ queryKey: queryKeys.pageData });
-  };
+  return () => queryClient.invalidateQueries({ queryKey: queryKeys.pageData });
 };

--- a/src/data/services/lms/hooks/selectors/oraConfig.ts
+++ b/src/data/services/lms/hooks/selectors/oraConfig.ts
@@ -46,13 +46,6 @@ export const useEffectiveGradeStep = () => {
   const order = useAssessmentStepOrder();
   return order[order.length - 1];
 };
-export const useFinalStep = () => {
-  const steps = useAssessmentStepOrder().filter(step => step !== stepNames.staff);
-  if (steps.length) {
-    return steps[steps.length - 1];
-  }
-  return stepNames.submission;
-};
 
 export const useRubricConfig = (): types.RubricConfig => useORAConfigData().rubricConfig;
 export const useEmptyRubric = () => {

--- a/src/hooks/assessment.js
+++ b/src/hooks/assessment.js
@@ -72,7 +72,6 @@ export const useCheckTrainingSelection = () => {
 export const useInitializeAssessment = () => {
   const emptyRubric = lmsSelectors.useEmptyRubric();
   const setFormFields = reduxHooks.useSetFormFields();
-  const setHasSubmitted = reduxHooks.useSetHasSubmitted();
   return React.useCallback(() => {
     setFormFields(emptyRubric);
   }, []);


### PR DESCRIPTION
Should enable real actions by default and override to mock behavior with the same command as for mock fetch data.