### PR TITLE
chore: rewrite modal container

### DIFF
--- a/src/components/ModalContainer.jsx
+++ b/src/components/ModalContainer.jsx
@@ -1,31 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FullscreenModal } from '@edx/paragon';
-
-import { nullMethod } from 'utils';
 import { useORAConfigData } from 'hooks/app';
 
 import ProgressBar from 'components/ProgressBar';
 
 /* The purpose of this component is to wrap views with a header/footer for situations
- * where we need to run non-embedded
+ * where we need to run non-embedded. It is a replicated style of FullScreenModal from
+ * paragon. The reason we use this instead of FullScreenModal is because FullScreenModal
+ * is very opinionated on other components that it uses on top of it. Since we are not
+ * using the modality of the component, it would be better to just replicate the style
+ * instead of using the component.
  */
 
 const ModalContainer = ({ children }) => {
   const { title } = useORAConfigData();
   return (
-    <FullscreenModal
-      isOpen
-      onClose={nullMethod}
-      hasCloseButton={false}
-      title={title}
-      modalBodyClassName="content-body bg-light-300"
-      beforeBodyNode={<ProgressBar className="px-2" />}
-    >
-      <div className="h-100">
+    <div className="h-100">
+      <div className="sticky-top bg-white">
+        <h3 className="bg-dark text-white p-3 m-0">{title}</h3>
+        <ProgressBar className="px-2 shadow-sm" />
+      </div>
+      <div className="content-body bg-light-300 p-4">
         {children}
       </div>
-    </FullscreenModal>
+    </div>
   );
 };
 ModalContainer.propTypes = {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -25,13 +25,6 @@ const queryClient = new QueryClient({
 subscribe(APP_READY, () => {
   const isDev = process.env.NODE_ENV === 'development';
   const rootEl = document.getElementById('root');
-  if (isDev) {
-    setTimeout(() => {
-      // This is a hack to prevent the Paragon Modal overlay stop query devtools from clickable
-      rootEl.removeAttribute('data-focus-on-hidden');
-      rootEl.removeAttribute('aria-hidden');
-    }, 3000);
-  }
   ReactDOM.render(
     <AppProvider store={store}>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
- rewrite modal container to use regular dom instead Fullscreen modal from paragon

The only noticable change will be the shadow on the bottom of the progress bar. I didn't want to write js to keep track of scrolling and hide it when the scroll is at the top. 

Old:
![Screenshot 2023-12-06 at 12 34 45 PM](https://github.com/openedx/frontend-app-ora/assets/83240113/d2b24e49-3b0f-4169-9423-d18f8f2312b0)

New:
![image](https://github.com/openedx/frontend-app-ora/assets/83240113/b5bc655a-a21f-4a86-9a76-06f5d96a46d1)
