### PR TITLE
Deprecate react-test-utils other utils 2/2

### DIFF
--- a/src/components/FilePreview/components/constants.ts
+++ b/src/components/FilePreview/components/constants.ts
@@ -1,5 +1,3 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
-
 import {
   PDFRenderer,
   ImageRenderer,
@@ -8,16 +6,16 @@ import {
 
 import messages from './messages';
 
-export const errorStatuses = StrictDict({
+export const errorStatuses = {
   badRequest: 400,
   unauthorized: 401,
   forbidden: 403,
   notFound: 404,
   conflict: 409,
   serverError: 500,
-});
+} as const;
 
-export const fileTypes = StrictDict({
+export const fileTypes = {
   pdf: 'pdf',
   jpg: 'jpg',
   jpeg: 'jpeg',
@@ -29,7 +27,7 @@ export const fileTypes = StrictDict({
   pjpeg: 'pjpeg',
   pjp: 'pjp',
   svg: 'svg',
-});
+} as const;
 
 export const errorMessages = {
   [errorStatuses.notFound]: messages.fileNotFoundError,

--- a/src/components/ProgressBar/ProgressStep.jsx
+++ b/src/components/ProgressBar/ProgressStep.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { StrictDict } from '@edx/react-unit-test-utils';
 import { Nav, Icon } from '@openedx/paragon';
 import {
   CheckCircle,
@@ -15,13 +14,13 @@ import {
 import { stepNames } from 'constants/index';
 import { useProgressStepData } from './hooks';
 
-export const stepIcons = StrictDict({
+export const stepIcons = {
   [stepNames.submission]: Edit,
   [stepNames.studentTraining]: Highlight,
   [stepNames.self]: Highlight,
   [stepNames.peer]: Highlight,
   [stepNames.done]: Rule,
-});
+};
 
 const ProgressStep = ({
   step,

--- a/src/constants/eventTypes.js
+++ b/src/constants/eventTypes.js
@@ -1,6 +1,0 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
-
-export default StrictDict({
-  modalClose: 'plugin.modal-close',
-  modalOpen: 'plugin.modal',
-});

--- a/src/constants/eventTypes.ts
+++ b/src/constants/eventTypes.ts
@@ -1,0 +1,4 @@
+export default {
+  modalClose: 'plugin.modal-close',
+  modalOpen: 'plugin.modal',
+} as const;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,24 +1,22 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
-
-export const feedbackRequirement = StrictDict({
+export const feedbackRequirement = Object.freeze({
   disabled: 'disabled',
   required: 'required',
   optional: 'optional',
 });
 
-export const queryKeys = StrictDict({
+export const queryKeys = Object.freeze({
   oraConfig: 'oraConfig',
   pageData: 'pageData',
 });
 
-export const MutationStatus = StrictDict({
+export const MutationStatus = Object.freeze({
   idle: 'idle',
   loading: 'loading',
   error: 'error',
   success: 'success',
 });
 
-export const stepStates = StrictDict({
+export const stepStates = Object.freeze({
   inProgress: 'inProgress',
   done: 'done',
   cancelled: 'cancelled',
@@ -32,12 +30,12 @@ export const stepStates = StrictDict({
   trainingValidation: 'trainingValidation', // ui-only
 });
 
-export const closedReasons = StrictDict({
+export const closedReasons = Object.freeze({
   pastDue: 'pastDue',
   notAvailable: 'notAvailable', // (yet)
 });
 
-export const stepNames = StrictDict({
+export const stepNames = Object.freeze({
   xblock: 'xblock',
   xblockStudio: 'xblockStudio',
   xblockPreview: 'xblockPreview',
@@ -55,7 +53,7 @@ export const assessmentSteps = [
   stepNames.peer,
 ];
 
-export const routeSteps = StrictDict({
+export const routeSteps = Object.freeze({
   xblock: stepNames.xblock,
   xblock_studio: stepNames.xblockStudio,
   xblock_preview: stepNames.xblockPreview,
@@ -66,7 +64,7 @@ export const routeSteps = StrictDict({
   graded: stepNames.done,
 });
 
-export const stepRoutes = StrictDict(Object.keys(routeSteps).reduce(
+export const stepRoutes = Object.freeze(Object.keys(routeSteps).reduce(
   (curr, route) => ({ ...curr, [routeSteps[route]]: route }),
   {},
 ));

--- a/src/constants/mockData.js
+++ b/src/constants/mockData.js
@@ -1,7 +1,6 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
 import { stepNames } from '.';
 
-export const viewKeys = StrictDict({
+export const viewKeys = {
   xblock: 'xblock',
   xblockStudio: 'xblock_studio',
   xblockPreview: 'xblock_preview',
@@ -10,9 +9,9 @@ export const viewKeys = StrictDict({
   self: 'self_assessment',
   peer: 'peer_assessment',
   done: 'graded',
-});
+};
 
-export const progressKeys = StrictDict({
+export const progressKeys = {
   cancelledDuringSubmission: 'cancelled_during_submission',
   cancelledDuringStudentTraining: 'cancelled_during_student_training',
   cancelledDuringSelf: 'cancelled_during_self',
@@ -44,7 +43,7 @@ export const progressKeys = StrictDict({
   staffAfterPeer: 'staff_after_peer',
   graded: 'graded',
   gradedSubmittedOnPreviousTeam: 'graded_submitted_on_previous_team',
-});
+};
 
 export const teamStates = [
   progressKeys.gradedSubmittedOnPreviousTeam,
@@ -58,7 +57,7 @@ export const closedStates = {
   closed: { isClosed: true, closedReason: 'pastDue' },
 };
 
-export const stepConfigs = StrictDict({
+export const stepConfigs = {
   all: [stepNames.studentTraining, stepNames.self, stepNames.peer, stepNames.staff],
   self: [stepNames.self],
   peer: [stepNames.peer],
@@ -66,14 +65,14 @@ export const stepConfigs = StrictDict({
   trainingAndSelf: [stepNames.studentTraining, stepNames.self],
   trainingAndPeer: [stepNames.studentTraining, stepNames.peer],
   selfAndStaff: [stepNames.self, stepNames.staff],
-});
+};
 
 export const stateStepConfigs = {
   [progressKeys.staffAfterSubmission]: stepConfigs.staff,
   [progressKeys.staffAfterSelf]: stepConfigs.selfAndStaff,
 };
 
-export const defaultViewProgressKeys = StrictDict({
+export const defaultViewProgressKeys = {
   [viewKeys.xblock]: progressKeys.submissionUnsaved,
   [viewKeys.xblockStudio]: progressKeys.submissionUnsaved,
   [viewKeys.xblockPreview]: progressKeys.submissionUnsaved,
@@ -82,4 +81,4 @@ export const defaultViewProgressKeys = StrictDict({
   [viewKeys.self]: progressKeys.selfAssessment,
   [viewKeys.peer]: progressKeys.peerAssessment,
   [viewKeys.done]: progressKeys.graded,
-});
+};

--- a/src/data/redux/app/reducer.ts
+++ b/src/data/redux/app/reducer.ts
@@ -1,7 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-
-import { StrictDict } from '@edx/react-unit-test-utils';
-
 import * as types from './types';
 
 const initialState = {
@@ -106,7 +103,7 @@ const app = createSlice({
   },
 });
 
-const actions = StrictDict(app.actions);
+const { actions } = app;
 
 const { reducer } = app;
 

--- a/src/data/redux/app/selectors.test.ts
+++ b/src/data/redux/app/selectors.test.ts
@@ -1,4 +1,4 @@
-import { keyStore } from '@edx/react-unit-test-utils';
+import { keyStore } from '../../../utils';
 
 import selectors from './selectors';
 

--- a/src/data/services/lms/fakeData/pageData/progress.js
+++ b/src/data/services/lms/fakeData/pageData/progress.js
@@ -1,5 +1,3 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
-
 import { stepNames } from 'constants/index';
 import { closedStates, progressKeys } from 'constants/mockData';
 import { isXblockStep } from 'utils';
@@ -32,23 +30,23 @@ export const createSubmissionStatus = ({
   cancelled_at: has_cancelled ? '2023-04-14T20:00:00Z' : null,
 });
 
-const subStatuses = StrictDict({
+const subStatuses = {
   cancelled: createSubmissionStatus({ has_cancelled: true }),
   cancelledAfterSubmission: createSubmissionStatus({ has_submitted: true, has_cancelled: true }),
   closed: createSubmissionStatus({ closedState: closedStates.closed }),
   notAvailable: createSubmissionStatus({ closedState: closedStates.notAvailable }),
   unsubmitted: createSubmissionStatus(),
   submitted: createSubmissionStatus({ has_submitted: true }),
-});
+};
 
-const teamStatuses = StrictDict({
+const teamStatuses = {
   unsubmitted: createTeamInfo(),
   submitted: createTeamInfo({ has_submitted: true }),
   previousTeam: createTeamInfo({ previous_team_name: 'Previous Team Name' }),
   needTeam: createTeamInfo({ team_name: null, team_usernames: null }),
-});
+};
 
-const teamSubStatuses = StrictDict({
+const teamSubStatuses = {
   cancelled: { ...subStatuses.cancelled, team_info: teamStatuses.unsubmitted },
   cancelledAfterSubmission: {
     ...subStatuses.cancelledAfterSubmission,
@@ -61,7 +59,7 @@ const teamSubStatuses = StrictDict({
   teamAlreadySubmitted: { ...subStatuses.unsubmitted, team_info: teamStatuses.submitted },
   submittedOnPreviousTeam: { ...subStatuses.submitted, team_info: teamStatuses.previousTeam },
   needTeam: { ...subStatuses.unsubmitted, team_info: teamStatuses.needTeam },
-});
+};
 
 export const createPeerStepInfo = ({
   closedState = closedStates.open,
@@ -75,7 +73,7 @@ export const createPeerStepInfo = ({
   number_of_received_assessments: numReceived,
 });
 
-const peerStatuses = StrictDict({
+const peerStatuses = {
   unsubmitted: createPeerStepInfo(),
   closed: createPeerStepInfo({ closedState: closedStates.closed }),
   notAvailable: createPeerStepInfo({ closedState: closedStates.notAvailable }),
@@ -88,7 +86,7 @@ const peerStatuses = StrictDict({
     isWaiting: false,
     numReceived: assessmentSteps.settings.peer.min_number_to_be_graded_by,
   }),
-});
+};
 
 export const createTrainingStepInfo = ({
   closedState = closedStates.open,
@@ -113,12 +111,12 @@ const trainingStatuses = {
   }),
 };
 
-const finishedStates = StrictDict({
+const finishedStates = {
   [stepNames.submission]: subStatuses.submitted,
   [stepNames.studentTraining]: trainingStatuses.finished,
   [stepNames.self]: closedStates.open,
   [stepNames.peer]: peerStatuses.finished,
-});
+};
 
 const nullStepInfo = { student_training: null, self: null, peer: null };
 
@@ -192,7 +190,7 @@ export const getProgressState = ({ viewStep, progressKey, stepConfig }) => {
     createProgressData(stepNames.staff, { step: stepNames.staff, ...stepInfoData })
   );
 
-  const mapping = StrictDict({
+  const mapping = {
     [progressKeys.cancelledDuringSubmission]: createCancelledState(stepNames.submission),
     [progressKeys.cancelledDuringStudentTraining]: createCancelledState(stepNames.studentTraining),
     [progressKeys.cancelledDuringSelf]: createCancelledState(stepNames.self),
@@ -233,7 +231,7 @@ export const getProgressState = ({ viewStep, progressKey, stepConfig }) => {
       createProgressData(stepConfig[stepConfig.length - 1], { isGraded: true }),
     [progressKeys.gradedSubmittedOnPreviousTeam]:
       createProgressData(stepConfig[stepConfig.length - 1], { isGraded: true }),
-  });
+  };
   return mapping[progressKey];
 };
 

--- a/src/data/services/lms/fakeData/pageData/response.js
+++ b/src/data/services/lms/fakeData/pageData/response.js
@@ -1,6 +1,4 @@
 /* eslint-disable camelcase */
-import { StrictDict } from '@edx/react-unit-test-utils';
-
 import { progressKeys } from 'constants/mockData';
 
 const files = [
@@ -50,7 +48,7 @@ export const createResponse = ({
   team_uploaded_files,
 });
 
-export const states = StrictDict({
+export const states = {
   individual: {
     empty: createResponse({
       text_responses: ['', ''],
@@ -74,7 +72,7 @@ export const states = StrictDict({
       team_uploaded_files: createFiles(3, { isTeam: true }),
     }),
   },
-});
+};
 
 export const getResponseState = ({ progressKey, isTeam }) => {
   if ([
@@ -103,6 +101,6 @@ export const getResponseState = ({ progressKey, isTeam }) => {
     : states.team.filled;
 };
 
-export default StrictDict({
+export default {
   getResponseState,
-});
+};

--- a/src/data/services/lms/hooks/selectors/index.ts
+++ b/src/data/services/lms/hooks/selectors/index.ts
@@ -1,4 +1,3 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
 import moment from 'moment';
 
 import {
@@ -152,11 +151,11 @@ export const useTextResponses = () => {
   return response ? response.textResponses : prompts.map(() => '');
 };
 
-const exported = StrictDict({
+const exported = {
   ...selectors,
   useStepState,
   useXBlockState,
   useActiveStepConfig,
   useGlobalState,
-});
+} as const;
 export default exported;

--- a/src/data/services/lms/index.js
+++ b/src/data/services/lms/index.js
@@ -1,12 +1,11 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
 import urls from './urls';
 import data from './hooks/data';
 import selectors from './hooks/selectors';
 import actions from './hooks/actions';
 
-export default StrictDict({
+export default {
   data,
   selectors,
   urls,
   actions,
-});
+};

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { StrictDict } from '@edx/react-unit-test-utils';
 import { getConfig } from '@edx/frontend-platform';
 
 import { stepNames, stepRoutes } from 'constants/index';
@@ -50,7 +49,7 @@ export const useAddFileUrl = () => `${useBaseUrl()}${paths.addFile}`;
 export const useUploadResponseUrl = () => `${useBaseUrl()}${paths.uploadResponse}`;
 export const useDeleteFileUrl = () => `${useBaseUrl()}${paths.deleteFile}`;
 
-export default StrictDict({
+export default {
   useORAConfigUrl,
   usePageDataUrl,
-});
+};

--- a/src/hooks/actions/useConfirmAction.js
+++ b/src/hooks/actions/useConfirmAction.js
@@ -1,11 +1,6 @@
-import React from 'react';
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils';
+import { useState, useCallback } from 'react';
 
 import { stepNames } from 'constants/index';
-
-export const stateKeys = StrictDict({
-  isOpen: 'isOpen',
-});
 
 export const assessmentSteps = [
   stepNames.studentTraining,
@@ -14,14 +9,14 @@ export const assessmentSteps = [
 ];
 
 const useConfirmAction = (validateBeforeOpen = () => true) => {
-  const [isOpen, setIsOpen] = useKeyedState(stateKeys.isOpen, false);
-  const close = React.useCallback(() => setIsOpen(false), [setIsOpen]);
-  const open = React.useCallback(() => {
+  const [isOpen, setIsOpen] = useState(false);
+  const close = useCallback(() => setIsOpen(false), [setIsOpen]);
+  const open = useCallback(() => {
     if (validateBeforeOpen()) {
       setIsOpen(true);
     }
   }, [setIsOpen, validateBeforeOpen]);
-  return React.useCallback((config) => {
+  return useCallback((config) => {
     const { description, title } = config;
     const action = config.action.action ? config.action.action : config.action;
     const confirmProps = {

--- a/src/hooks/actions/useConfirmAction.test.js
+++ b/src/hooks/actions/useConfirmAction.test.js
@@ -39,7 +39,7 @@ describe('useConfirmAction', () => {
   describe('behavior', () => {
     it('initializes isOpen state to false', () => {
       useConfirmAction(validateBeforeOpen);
-      expect(setStateSpy).toHaveBeenCalledWith(false);
+      expect(setStateSpy).toHaveBeenCalledWith(false); // isOpen initial state
     });
   });
   describe('output callback', () => {
@@ -47,12 +47,12 @@ describe('useConfirmAction', () => {
     const testClose = (closeFn) => {
       expect(closeFn.useCallback.prereqs).toEqual([setValue]);
       closeFn.useCallback.cb();
-      expect(setStateSpy).toHaveBeenCalledWith(false);
+      expect(setStateSpy).toHaveBeenCalledWith(false); // isOpen set to false
     };
     const testOpen = (openFn) => {
       expect(openFn.useCallback.prereqs).toEqual([setValue, validateBeforeOpen]);
       openFn.useCallback.cb();
-      expect(setValue).toHaveBeenCalledWith(true);
+      expect(setValue).toHaveBeenCalledWith(true); // isOpen set to true
     };
     describe('prereqs', () => {
       beforeEach(() => {

--- a/src/hooks/actions/useConfirmAction.test.js
+++ b/src/hooks/actions/useConfirmAction.test.js
@@ -1,8 +1,5 @@
-import { mockUseKeyedState } from '@edx/react-unit-test-utils';
-
-import useConfirmAction, { stateKeys } from './useConfirmAction';
-
-const state = mockUseKeyedState(stateKeys);
+import React from 'react';
+import useConfirmAction from './useConfirmAction';
 
 const config = {
   title: 'test-title',
@@ -27,31 +24,39 @@ const validateBeforeOpen = jest.fn(() => true);
 
 let out;
 describe('useConfirmAction', () => {
+  let setStateSpy;
+  const setValue = jest.fn();
+
   beforeEach(() => {
-    jest.clearAllMocks();
-    state.mock();
-    out = useConfirmAction(validateBeforeOpen);
+    setStateSpy = jest.spyOn(React, 'useState').mockImplementation((value) => [value, setValue]);
   });
-  afterEach(() => { state.resetVals(); });
+
+  afterEach(() => {
+    setStateSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
   describe('behavior', () => {
     it('initializes isOpen state to false', () => {
-      state.expectInitializedWith(stateKeys.isOpen, false);
+      useConfirmAction(validateBeforeOpen);
+      expect(setStateSpy).toHaveBeenCalledWith(false);
     });
   });
   describe('output callback', () => {
     let prereqs;
     const testClose = (closeFn) => {
-      expect(closeFn.useCallback.prereqs).toEqual([state.setState[stateKeys.isOpen]]);
+      expect(closeFn.useCallback.prereqs).toEqual([setValue]);
       closeFn.useCallback.cb();
-      state.expectSetStateCalledWith(stateKeys.isOpen, false);
+      expect(setStateSpy).toHaveBeenCalledWith(false);
     };
     const testOpen = (openFn) => {
-      expect(openFn.useCallback.prereqs).toEqual([state.setState[stateKeys.isOpen], validateBeforeOpen]);
+      expect(openFn.useCallback.prereqs).toEqual([setValue, validateBeforeOpen]);
       openFn.useCallback.cb();
-      state.expectSetStateCalledWith(stateKeys.isOpen, true);
+      expect(setValue).toHaveBeenCalledWith(true);
     };
     describe('prereqs', () => {
       beforeEach(() => {
+        out = useConfirmAction(validateBeforeOpen);
         ({ prereqs } = out.useCallback);
       });
       test('close callback', () => {
@@ -59,7 +64,7 @@ describe('useConfirmAction', () => {
       });
       test('isOpen value', () => {
         expect(out.useCallback.prereqs[1]).toEqual(false);
-        state.mockVal(stateKeys.isOpen, true);
+        setStateSpy.mockImplementation(() => [true, setValue]);
         out = useConfirmAction();
         expect(out.useCallback.prereqs[1]).toEqual(true);
       });
@@ -90,7 +95,7 @@ describe('useConfirmAction', () => {
         testClose(out.confirmProps.close);
       });
       it('returns action with children from config action', () => {
-        state.mockVals({ [stateKeys.isOpen]: true });
+        setStateSpy.mockImplementation(() => [true, setValue]);
         out = useConfirmAction(validateBeforeOpen).useCallback.cb(noLabelConfig);
         testOpen(out.action.onClick);
         expect(out.action.children).toEqual(noLabelConfig.action.children);

--- a/src/hooks/actions/useDeleteFileAction.test.js
+++ b/src/hooks/actions/useDeleteFileAction.test.js
@@ -1,7 +1,6 @@
 import { when } from 'jest-when';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { formatMessage } from '@edx/react-unit-test-utils';
 
 import useConfirmAction from './useConfirmAction';
 import messages, { confirmTitles, confirmDescriptions } from './messages';
@@ -32,12 +31,12 @@ describe('useDeleteFileAction', () => {
       expect(prereqs).toEqual([props.fileIndex, props.onDeletedFile]);
       cb();
       expect(props.onDeletedFile).toHaveBeenCalledWith(props.fileIndex);
-      expect(action.children).toEqual(formatMessage(messages.deleteFile));
+      expect(action.children).toEqual(messages.deleteFile.defaultMessage);
     });
     test('wrapped action with tile and description from messages', () => {
       const { title, description } = out.confirmAction;
-      expect(title).toEqual(formatMessage(confirmTitles.deleteFile));
-      expect(description).toEqual(formatMessage(confirmDescriptions.deleteFile));
+      expect(title).toEqual(confirmTitles.deleteFile.defaultMessage);
+      expect(description).toEqual(confirmDescriptions.deleteFile.defaultMessage);
     });
   });
 });

--- a/src/hooks/actions/useExitWithoutSavingAction.test.js
+++ b/src/hooks/actions/useExitWithoutSavingAction.test.js
@@ -1,7 +1,6 @@
 import { when } from 'jest-when';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { formatMessage } from '@edx/react-unit-test-utils';
 
 import useConfirmAction from './useConfirmAction';
 import { useCloseAction } from './simpleActions';
@@ -35,10 +34,10 @@ describe('useExitWithoutSavingAction', () => {
     it('returns close action with exitWithoutSaving message', () => {
       expect(out.confirmAction.action).toEqual(closeAction(messages.exitWithoutSaving));
     });
-    it('wraps with tidle and description from messages', () => {
+    it('wraps with title and description from messages', () => {
       const { title, description } = out.confirmAction;
-      expect(title).toEqual(formatMessage(confirmTitles.exit));
-      expect(description).toEqual(formatMessage(confirmDescriptions.exit));
+      expect(title).toEqual(confirmTitles.exit.defaultMessage);
+      expect(description).toEqual(confirmDescriptions.exit.defaultMessage);
     });
   });
 });

--- a/src/hooks/actions/useLoadNextAction.test.js
+++ b/src/hooks/actions/useLoadNextAction.test.js
@@ -1,6 +1,5 @@
 import { when } from 'jest-when';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { formatMessage } from '@edx/react-unit-test-utils';
 
 import {
   usePageDataStatus,
@@ -81,13 +80,13 @@ describe('useLoadNextAction', () => {
         const { state, labels } = out.action;
         expect(state).toEqual(pageDataStatus.status);
         expect(labels.default).toEqual(
-          `${formatMessage(messages.loadNext)} ${formatMessage(loadNextSteps[stepNames.peer])}`,
+          `${messages.loadNext.defaultMessage} ${loadNextSteps[stepNames.peer].defaultMessage}`,
         );
         expect(labels[MutationStatus.idle]).toEqual(
-          `${formatMessage(messages.loadNext)} ${formatMessage(loadNextSteps[stepNames.peer])}`,
+          `${messages.loadNext.defaultMessage} ${loadNextSteps[stepNames.peer].defaultMessage}`,
         );
         expect(labels[MutationStatus.loading]).toEqual(
-          `${formatMessage(messages.loadingNext)} ${formatMessage(loadNextSteps[stepNames.peer])}`,
+          `${messages.loadingNext.defaultMessage} ${loadNextSteps[stepNames.peer].defaultMessage}`,
         );
       });
       it('loads status from page data status', () => {

--- a/src/hooks/actions/useStartStepAction.test.js
+++ b/src/hooks/actions/useStartStepAction.test.js
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import { when } from 'jest-when';
-import { formatMessage } from '@edx/react-unit-test-utils';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Rule } from '@openedx/paragon/icons';
 
@@ -39,7 +38,7 @@ describe('useStartStepAction', () => {
     it('returns Rule icon action for done step', () => {
       when(useActiveStepName).calledWith().mockReturnValueOnce(stepNames.done);
       const { children, href, iconBefore } = useStartStepAction().action;
-      expect(children).toEqual(formatMessage(messages.viewGrades));
+      expect(children).toEqual(messages.viewGrades.defaultMessage);
       expect(href).toEqual(`/${stepRoutes.done}/${courseId}/${xblockId}`);
       expect(iconBefore).toEqual(Rule);
     });
@@ -48,7 +47,7 @@ describe('useStartStepAction', () => {
         test(step, () => {
           when(useActiveStepName).calledWith().mockReturnValueOnce(step);
           const { children, href, iconBefore } = useStartStepAction().action;
-          expect(children).toEqual(formatMessage(message));
+          expect(children).toEqual(message.defaultMessage);
           expect(href).toEqual(`/${stepRoutes[step]}/${courseId}/${xblockId}`);
           expect(iconBefore).toBeUndefined();
         });

--- a/src/hooks/actions/useSubmitResponseAction.test.js
+++ b/src/hooks/actions/useSubmitResponseAction.test.js
@@ -1,5 +1,4 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { formatMessage } from '@edx/react-unit-test-utils';
 import { when } from 'jest-when';
 
 import { MutationStatus, stepNames } from 'constants/index';
@@ -35,16 +34,16 @@ describe('useSubmitResponseAction', () => {
   describe('output confirmAction', () => {
     it('returns a confirmAction with title and description from messages', () => {
       const { title, description } = out.confirmAction;
-      expect(title).toEqual(formatMessage(confirmTitles[stepNames.submission]));
-      expect(description).toEqual(formatMessage(confirmDescriptions[stepNames.submission]));
+      expect(title).toEqual(confirmTitles[stepNames.submission].defaultMessage);
+      expect(description).toEqual(confirmDescriptions[stepNames.submission].defaultMessage);
     });
     test('passed action loads cb and status from params and labels from messages', () => {
       const { onClick, state, labels } = out.confirmAction.action;
       expect(onClick).toEqual(options.submit);
       expect(state).toEqual(options.submitStatus);
       expect(labels).toEqual({
-        default: formatMessage(messages.submitResponse),
-        [MutationStatus.loading]: formatMessage(messages.submittingResponse),
+        default: messages.submitResponse.defaultMessage,
+        [MutationStatus.loading]: messages.submittingResponse.defaultMessage,
       });
     });
   });

--- a/src/hooks/app.test.js
+++ b/src/hooks/app.test.js
@@ -1,5 +1,3 @@
-// import { keyStore } from '@edx/react-unit-test-utils';
-
 import * as reduxHooks from 'data/redux/hooks';
 import * as lmsSelectors from 'data/services/lms/hooks/selectors/index';
 import * as lmsActions from 'data/services/lms/hooks/actions';

--- a/src/hooks/assessment.test.js
+++ b/src/hooks/assessment.test.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { when } from 'jest-when';
 
-import { keyStore, getEffects } from '@edx/react-unit-test-utils';
+import { getEffects } from '@edx/react-unit-test-utils';
 
 import { stepNames } from 'constants/index';
 
 import * as reduxHooks from 'data/redux/hooks';
 import * as lmsSelectors from 'data/services/lms/hooks/selectors';
 import * as lmsActions from 'data/services/lms/hooks/actions';
+import { keyStore } from '../utils';
 
 import * as routingHooks from './routing';
 import { useIsMounted } from './utils';

--- a/src/hooks/assessment.test.js
+++ b/src/hooks/assessment.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { when } from 'jest-when';
 
-import { getEffects } from '@edx/react-unit-test-utils';
-
 import { stepNames } from 'constants/index';
 
 import * as reduxHooks from 'data/redux/hooks';
@@ -196,8 +194,7 @@ describe('Assessment hooks', () => {
       });
       it('calls setResponse with response on first load', () => {
         prepHook();
-        const [cb] = getEffects([], React);
-        cb();
+        React.useEffect.mock.calls[0][0]();
         expect(setResponse).toHaveBeenCalledWith(testResponse);
       });
     });

--- a/src/hooks/utils.test.js
+++ b/src/hooks/utils.test.js
@@ -1,23 +1,35 @@
 import React from 'react';
-import { when } from 'jest-when';
-import { getEffects } from '@edx/react-unit-test-utils';
 
 import { useIsMounted } from './utils';
 
-when(React.useRef).calledWith(false).mockReturnValue({ current: false });
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useRef: jest.fn((val) => ({ current: val, useRef: true })),
+  useEffect: jest.fn((cb, prereqs) => ({ useEffect: { cb, prereqs } })),
+}));
 
-let out;
 describe('useIsMounted', () => {
+  let useRef;
+  let useEffect;
+
+  beforeEach(() => {
+    useRef = jest.spyOn(React, 'useRef');
+    useEffect = jest.spyOn(React, 'useEffect');
+  });
   it('creates a ref with initial value false', () => {
-    out = useIsMounted();
-    expect(React.useRef).toHaveBeenCalledWith(false);
+    useIsMounted();
+    expect(useRef).toHaveBeenCalledWith(false);
   });
   it('sets mounted.current to true on mount and false on unmount', () => {
-    out = useIsMounted();
-    const [effect] = getEffects([], React);
-    const returned = effect();
-    expect(out.current).toBe(true);
-    returned();
-    expect(out.current).toBe(false);
+    const result = useIsMounted();
+    expect(result.current).toBe(false); // initial value
+
+    // Call the effect callback and get the cleanup function
+    const cleanup = useEffect.mock.calls[0][0]();
+    expect(result.current).toBe(true);
+
+    // Call cleanup to simulate unmount
+    cleanup();
+    expect(result.current).toBe(false);
   });
 });

--- a/src/views/AssessmentView/useAssessmentData.js
+++ b/src/views/AssessmentView/useAssessmentData.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils';
+import { useState, useEffect } from 'react';
 import {
   useIsORAConfigLoaded,
   useIsPageDataLoaded,
@@ -9,19 +8,15 @@ import {
   useResponseData,
 } from 'hooks/app';
 
-export const stateKeys = StrictDict({
-  initialized: 'initialized',
-});
-
 const useAssessmentData = () => {
-  const [initialized, setInitialized] = useKeyedState(stateKeys.initialized, false);
+  const [initialized, setInitialized] = useState(false);
   const prompts = usePrompts();
   const response = useResponse();
   const responseData = useResponseData();
   const setResponse = useSetResponse();
   const isLoaded = useIsORAConfigLoaded();
   const isPageDataLoaded = useIsPageDataLoaded();
-  React.useEffect(() => {
+  useEffect(() => {
     if (!initialized && isLoaded && isPageDataLoaded) {
       setResponse(responseData);
       setInitialized(true);

--- a/src/views/SubmissionView/hooks/useSubmissionViewData.js
+++ b/src/views/SubmissionView/hooks/useSubmissionViewData.js
@@ -1,7 +1,4 @@
-import React from 'react';
-
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils';
-
+import { useState, useCallback } from 'react';
 import {
   useGlobalState,
   useRubricConfig,
@@ -18,12 +15,8 @@ import useTextResponsesData from './useTextResponsesData';
 import useUploadedFilesData from './useUploadedFilesData';
 import useSubmissionValidationStatus from './useSubmissionValidationStatus';
 
-const stateKeys = StrictDict({
-  hasSavedDraft: 'hasSavedDraft',
-});
-
 const useSubmissionViewData = () => {
-  const [hasSavedDraft, setHasSavedDraft] = useKeyedState(stateKeys.hasSavedDraft, false);
+  const [hasSavedDraft, setHasSavedDraft] = useState(false);
   const hasSubmitted = useHasSubmitted();
   const setHasSubmitted = useSetHasSubmitted();
   const submitResponseMutation = useSubmitResponse();
@@ -56,7 +49,7 @@ const useSubmissionViewData = () => {
     fileUploadIsRequired,
   } = useSubmissionValidationStatus(textResponses, uploadedFiles);
 
-  const submitResponseHandler = React.useCallback(() => {
+  const submitResponseHandler = useCallback(() => {
     submitResponseMutation.mutateAsync({
       textResponses,
       uploadedFiles,

--- a/src/views/SubmissionView/hooks/useTextResponsesData.js
+++ b/src/views/SubmissionView/hooks/useTextResponsesData.js
@@ -1,6 +1,4 @@
-import { useCallback, useEffect } from 'react';
-
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils';
+import { useCallback, useEffect, useState } from 'react';
 import {
   useFinishLater,
   useHasSubmitted,
@@ -9,20 +7,13 @@ import {
 } from 'hooks/app';
 import { MutationStatus } from 'constants/index';
 
-export const stateKeys = StrictDict({
-  textResponses: 'textResponses',
-  isDirty: 'isDirty',
-  hasSaved: 'hasSaved',
-  lastChanged: 'lastChanged',
-});
-
 const useTextResponsesData = ({ setHasSavedDraft }) => {
   const textResponses = useTextResponses();
   const hasSubmitted = useHasSubmitted();
-  const [hasSaved, setHasSaved] = useKeyedState(stateKeys.hasSaved, false);
-  const [lastChanged, setLastChanged] = useKeyedState(stateKeys.lastChanged, null);
-  const [isDirty, setIsDirty] = useKeyedState(stateKeys.isDirty, false);
-  const [value, setValue] = useKeyedState(stateKeys.textResponses, textResponses);
+  const [hasSaved, setHasSaved] = useState(false);
+  const [lastChanged, setLastChanged] = useState(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [value, setValue] = useState(textResponses);
 
   const saveResponseMutation = useSaveDraftResponse();
   const finishLaterMutation = useFinishLater();

--- a/src/views/SubmissionView/hooks/useUploadedFilesData.js
+++ b/src/views/SubmissionView/hooks/useUploadedFilesData.js
@@ -1,6 +1,4 @@
-import React from 'react';
-
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils';
+import { useState, useEffect } from 'react';
 
 import {
   useResponseData,
@@ -8,20 +6,17 @@ import {
   useDeleteFile,
 } from 'hooks/app';
 
-export const stateKeys = StrictDict({ uploadedFiles: 'uploadedFiles' });
-
 const useUploadedFilesData = () => {
   const deleteFileMutation = useDeleteFile();
   const uploadFilesMutation = useUploadFiles();
 
   const response = useResponseData() || {};
 
-  const [value, setValue] = useKeyedState(
-    stateKeys.uploadedFiles,
+  const [value, setValue] = useState(
     response?.uploadedFiles ? response.uploadedFiles : [],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     setValue(response.uploadedFiles);
   }, [setValue, response.uploadedFiles]);
 

--- a/src/views/SubmissionView/hooks/useUploadedFilesData.test.js
+++ b/src/views/SubmissionView/hooks/useUploadedFilesData.test.js
@@ -40,13 +40,13 @@ describe('useUploadedFilesData', () => {
   it('initializes uploadedFiles state to empty array if response is null', () => {
     useResponseData.mockReturnValue();
     renderHook(() => useUploadedFilesData());
-    expect(setStateSpy).toHaveBeenCalledWith([]);
+    expect(setStateSpy).toHaveBeenCalledWith([]); // value initial state
   });
 
   it('initializes uploadedFiles state to response.uploadedFiles', () => {
     useResponseData.mockReturnValue({ uploadedFiles: ['file1', 'file2'] });
     renderHook(() => useUploadedFilesData());
-    expect(setStateSpy).toHaveBeenCalledWith(['file1', 'file2']);
+    expect(setStateSpy).toHaveBeenCalledWith(['file1', 'file2']); // value initial state
   });
 
   it('return correct mutation function', () => {

--- a/src/views/XBlockView/StatusRow/StatusBadge/useBadgeConfig.js
+++ b/src/views/XBlockView/StatusRow/StatusBadge/useBadgeConfig.js
@@ -1,5 +1,3 @@
-import { StrictDict } from '@edx/react-unit-test-utils';
-
 import { useGlobalState } from 'hooks/app';
 import {
   stepNames,
@@ -8,7 +6,7 @@ import {
 
 import messages from './messages';
 
-export const badgeConfig = StrictDict({
+export const badgeConfig = {
   [stepStates.cancelled]: { variant: 'danger', message: messages.cancelled },
   [stepStates.notAvailable]: { variant: 'light', message: messages.notAvailable },
   [stepStates.inProgress]: { variant: 'primary', message: messages.inProgress },
@@ -18,13 +16,13 @@ export const badgeConfig = StrictDict({
   [stepStates.waiting]: { variant: 'warning', message: messages.notReady },
   [stepStates.waitingForPeerGrades]: { variant: 'warning', message: messages.waiting },
   [stepNames.done]: { variant: 'success', message: messages.complete },
-  staffAfter: StrictDict({
+  staffAfter: {
     [stepNames.submission]: { variant: 'primary', message: messages.submitted },
     [stepNames.studentTraining]: { variant: 'primary', message: messages.practiceCompleted },
     [stepNames.self]: { variant: 'primary', message: messages.selfCompleted },
     [stepNames.peer]: { variant: 'primary', message: messages.peerCompleted },
-  }),
-});
+  },
+};
 
 const useBadgeConfig = () => {
   const {


### PR DESCRIPTION
### Description
On previous effort was missing deprecation of `formatMessage`, `useKeyedState`, `StrictDict` and `mockUseKeyedState`
So it was addressed on this PR.
- For `formatMessage` we removed it and just use the real defaultMessage to compare on tests.
- Was replaced `useKeyedState` by `useState` and in the related tests `mockUseKeyedState` was removed and replaced by a jest spy for native react `useState`.
- StrictDict was removed and in some cases replaced by `Object.freeze` or `as const` if is a typescript file.

#### Support Information
Closes #377 