### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
     - name: Setup Nodejs
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '.nvmrc'
     - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- Pins all pinnable GitHub Action \`uses:\` refs to full commit SHAs with human-readable version comments
- Generated using [pinact](https://github.com/suzuki-shunsuke/pinact) v3.10.0

## Context

Part of the org-wide SHA-pinning migration: openedx/.github#165

Resolves https://github.com/openedx/.github/issues/165

Reusable workflow calls (\`openedx/.github/.github/workflows/...@master\`) are intentionally left unpinned — they track the org's shared workflows by design.

## Test plan

- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)